### PR TITLE
feat(client): add profile preview on hover

### DIFF
--- a/libs/ui/components/src/lib/atoms/ProfileSummaryButton.tsx
+++ b/libs/ui/components/src/lib/atoms/ProfileSummaryButton.tsx
@@ -1,0 +1,33 @@
+import { colors } from '@tw/ui/assets';
+import React from 'react';
+import styled from 'styled-components';
+import { SecondaryButton } from './Button';
+
+type ProfileSummaryButtonProps = {
+  onClick?: () => void;
+};
+
+export const ProfileSummaryButton: React.FC<ProfileSummaryButtonProps> = ({ onClick }) => {
+  return (
+    <Button onClick={onClick}>
+      <strong>Profile Summary</strong>
+    </Button>
+  );
+};
+
+const Button = styled(SecondaryButton)`
+  width: 100%;
+  height: 2.286rem;
+  padding: 12px 16px;
+
+  color: ${colors.white};
+  background-color: ${colors.black};
+  font-weight: 400;
+  cursor: pointer;
+  font-size: 15px;
+  border: 0.5px solid ${colors.graySecondary} !important;
+
+  &:hover {
+    background-color: ${colors.grayDark};
+  }
+`;

--- a/libs/ui/components/src/lib/molecules/ProfilePreview.tsx
+++ b/libs/ui/components/src/lib/molecules/ProfilePreview.tsx
@@ -1,0 +1,150 @@
+import { PublicUserBase } from '@tw/data';
+import { colors } from '@tw/ui/assets'; // use your project's color palette
+import { InvalidationData } from '@tw/ui/common';
+import { usePublicUserSocialStatsQuery } from '@tw/ui/data-access';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+import { ConnectButton } from '../atoms/ConnectButton';
+import { ProfileSummaryButton } from '../atoms/ProfileSummaryButton';
+
+type ProfilePreviewProps = {
+  buttonRelatedUser: PublicUserBase;
+  meId: number;
+  publicUserId?: number;
+  showConnectButton?: boolean;
+  invData: InvalidationData;
+};
+
+export const ProfilePreview: React.FC<ProfilePreviewProps> = ({
+  buttonRelatedUser,
+  meId,
+  publicUserId,
+  showConnectButton,
+  invData,
+}) => {
+  const { id, name, avatar, uniqueName, bio, followingStatus } = buttonRelatedUser;
+  const { data: socialStats } = usePublicUserSocialStatsQuery(id);
+
+  return (
+    <Wrapper>
+      <Popup>
+        <Header>
+          <Avatar src={avatar} alt={name} />
+          {showConnectButton && (
+            <ConnectButton
+              meId={meId}
+              buttonRelatedUserId={id}
+              publicUserId={publicUserId}
+              followingStatus={followingStatus}
+              invData={invData}
+            />
+          )}
+        </Header>
+
+        <Content>
+          <NameBlock>
+            <NameLink to={`/public-profile/${id}`}>{name}</NameLink>
+            <Handle>{uniqueName}</Handle>
+          </NameBlock>
+          <Bio>{bio}</Bio>
+          <Stats>
+            <Stat>
+              <Count>{socialStats?.followingCount}</Count> <Label>Following</Label>
+            </Stat>
+            <Stat>
+              <Count>{socialStats?.followersCount}</Count> <Label>Followers</Label>
+            </Stat>
+          </Stats>
+
+          <ProfileSummaryButton onClick={() => console.log('click')} />
+        </Content>
+      </Popup>
+    </Wrapper>
+  );
+};
+
+// ================= Styled Components =================
+
+const Wrapper = styled.div`
+  position: relative;
+  display: inline-block;
+`;
+
+const Popup = styled.div`
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 10px;
+  padding: 20px 14px;
+  width: 300px;
+  background: ${colors.black};
+  color: ${colors.white};
+  border-radius: 16px;
+  /* subtle light shadow around the popup */
+  box-shadow: 0 0 8px 2px rgba(255, 255, 255, 0.2), 0 4px 12px rgba(255, 255, 255, 0.1);
+  z-index: 1000;
+`;
+
+const Header = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: top;
+  justify-content: space-between;
+`;
+
+const Avatar = styled.img`
+  width: 70px;
+  height: 70px;
+  border-radius: 50%;
+`;
+
+const NameBlock = styled.div``;
+
+const Handle = styled.div`
+  color: ${colors.graySecondary};
+  font-size: 14px;
+`;
+
+const Bio = styled.div`
+  margin-top: 8px;
+  font-size: 16px;
+  color: ${colors.white};
+`;
+
+const Stats = styled.div`
+  margin-top: 8px;
+  margin-bottom: 10px;
+  display: flex;
+  gap: 12px;
+  font-size: 14px;
+`;
+
+const Stat = styled.div``;
+
+const Count = styled.strong`
+  color: ${colors.white};
+`;
+
+const Label = styled.span`
+  color: ${colors.graySecondary};
+`;
+
+const Content = styled.div`
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  margin-left: 6px;
+`;
+
+const NameLink = styled(Link)`
+  color: ${colors.white};
+  text-decoration: none;
+  font-size: 17px;
+  font-weight: bold;
+  &:hover {
+    text-decoration: underline;
+  }
+`;

--- a/libs/ui/components/src/lib/molecules/SingleUser.tsx
+++ b/libs/ui/components/src/lib/molecules/SingleUser.tsx
@@ -1,9 +1,11 @@
+import Tippy from '@tippyjs/react';
 import { PublicUserBase } from '@tw/data';
 import { colors } from '@tw/ui/assets';
 import { InvalidationData, linksRecords } from '@tw/ui/common';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { ConnectButton } from '../atoms/ConnectButton';
+import { ProfilePreview } from './ProfilePreview';
 
 type SingleUserProps = {
   buttonRelatedUser: PublicUserBase;
@@ -105,15 +107,36 @@ export const SingleUser = (props: SingleUserProps) => {
 
   return (
     <Wrapper onClick={goToUserPage}>
-      <ProfileImage $backgroundImage={avatar} />
       <ContentWrapper>
         <ProfileWrapper>
-          <ContextWrapper>
-            <TextWrapper>
-              <H3>{name}</H3>
-              <Span>{uniqueName}</Span>
-            </TextWrapper>
-          </ContextWrapper>
+          <Tippy
+            interactive
+            placement="left"
+            delay={[300, 0]}
+            hideOnClick={false}
+            offset={[0, 120]}
+            content={
+              showUserPreview && (
+                <div onClick={(e) => e.stopPropagation()}>
+                  <ProfilePreview
+                    buttonRelatedUser={buttonRelatedUser}
+                    meId={meId}
+                    publicUserId={publicUserId}
+                    invData={invData}
+                    showConnectButton={showConnectButton}
+                  />
+                </div>
+              )
+            }
+          >
+            <ContextWrapper>
+              <ProfileImage $backgroundImage={avatar} />
+              <TextWrapper>
+                <H3>{name}</H3>
+                <Span>{uniqueName}</Span>
+              </TextWrapper>
+            </ContextWrapper>
+          </Tippy>
           {showConnectButton && (
             <ConnectButton
               meId={meId}
@@ -142,7 +165,6 @@ const Wrapper = styled.div`
 
 const ContentWrapper = styled.div`
   width: 100%;
-  padding-left: 0.8rem;
 `;
 
 const S = styled.span`
@@ -168,7 +190,7 @@ const ProfileImage = styled.div<{ $backgroundImage: string }>`
   min-width: 3.2rem;
   height: 3.2rem;
   background-color: ${colors.bluePrimary};
-
+  margin-right: 0.8rem;
   ${(props) =>
     props.$backgroundImage &&
     `


### PR DESCRIPTION
Added ProfilePreview component similar to Twitter.
Preview shows when hovering over the user’s avatar or name.
Added ProfileSummaryButton in the preview to match the twitters popup but it doesnt do anything.